### PR TITLE
fix: remove user benchmark misinformation

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,12 +98,12 @@
                     </section>
                     <section>
                         <h3>How do I compare CPUs easily?</h3>
-                        <p><a href="https://cpu.userbenchmark.com/Compare/Intel-Core-i3-12100F-vs-Group-/4125vs10" target="_blank">User Benchmark</a></p>
                         <p>
                             <small>
-                                For a good rough cut, this is a decent option.  It allows you to select CPUs across generations and compare their
-                                effective speed against one another.  Keep in mind that their data is user provided so can be skewed by thermal
-                                issues, windows updates, or other things people don't consider before benchmarking.
+                                Most comparison websites (such as User Benchmark) have very skewed or opinionated data that can make it hard to directly
+                                compare one CPU to the next.  The best way is to lookup reviews of a given CPU you are interested in from sites like
+			        [Gamer's Nexus](https://gamersnexus.net/cat/cpus), [Serve The Home](https://www.servethehome.com/category/workstations/workstation-processors/),
+			        or [Level One Techs](https://www.level1techs.com/article).
                             </small>
                         </p>
                     </section>
@@ -309,9 +309,8 @@
                         <p>
                             <small>
                                 GPUs can vary more than CPUs in frequency and core count so it is usually best to compare
-                                them in benchmarks for games that you intend to play.  As with CPUs,
-                                <a href="https://gpu.userbenchmark.com/Compare/Nvidia-RTX-3060-vs-Group-/4105vs10" target="_blank">User Benchmark</a>
-                                can help here.
+                                them in benchmarks for games that you intend to play.  As with CPUs, look for reputable reviews from places like
+                                [Gamer's Nexus](https://gamersnexus.net/cat/gpus) or [Level One Techs](https://www.level1techs.com/article).
                             </small>
                         </p>
                     </section>


### PR DESCRIPTION
Remove references to User Benchmark - they were "ok" in the Skylake era but recent reviews are _very_ skewed and it should not be recommended.